### PR TITLE
bugfix

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -582,7 +582,6 @@ export interface LossOfControlData {
     displayType: 0 | 1 | 2;
 }
 export declare const C_LossOfControl: {
-    GetEventInfo: (eventIndex: number) => [string, number, string, string, number, number, number, number, number, number];
     GetNumEvents: () => number;
     GetActiveLossOfControlData: (eventIndex: number) => LossOfControlData | undefined;
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -582,6 +582,6 @@ export interface LossOfControlData {
     displayType: 0 | 1 | 2;
 }
 export declare const C_LossOfControl: {
-    GetNumEvents: () => number;
+    GetActiveLossOfControlDataCount: () => number;
     GetActiveLossOfControlData: (eventIndex: number) => LossOfControlData | undefined;
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -584,5 +584,5 @@ export interface LossOfControlData {
 export declare const C_LossOfControl: {
     GetEventInfo: (eventIndex: number) => [string, number, string, string, number, number, number, number, number, number];
     GetNumEvents: () => number;
-    GetActiveLossOfControlData(eventIndex: number): LossOfControlData | undefined;
+    GetActiveLossOfControlData: (eventIndex: number) => LossOfControlData | undefined;
 };

--- a/index.js
+++ b/index.js
@@ -997,7 +997,7 @@ exports.C_AzeriteEssence = {
     },
 };
 exports.C_LossOfControl = {
-    GetNumEvents: () => {
+    GetActiveLossOfControlDataCount: () => {
         return 0;
     },
     GetActiveLossOfControlData: (eventIndex) => {

--- a/index.js
+++ b/index.js
@@ -997,20 +997,6 @@ exports.C_AzeriteEssence = {
     },
 };
 exports.C_LossOfControl = {
-    GetEventInfo: (eventIndex) => {
-        return [
-            "SCHOOL_INTERRUPT",
-            33786,
-            "Interrupted",
-            "texture",
-            0,
-            7,
-            8,
-            1,
-            0,
-            2,
-        ];
-    },
     GetNumEvents: () => {
         return 0;
     },

--- a/index.js
+++ b/index.js
@@ -1014,7 +1014,7 @@ exports.C_LossOfControl = {
     GetNumEvents: () => {
         return 0;
     },
-    GetActiveLossOfControlData(eventIndex) {
+    GetActiveLossOfControlData: (eventIndex) => {
         return {
             locType: "SCHOOL_INTERRUPT",
             spellID: 19,

--- a/index.ts
+++ b/index.ts
@@ -1228,7 +1228,7 @@ export interface LossOfControlData {
 }
 
 export const C_LossOfControl = {
-    GetNumEvents: () => {
+    GetActiveLossOfControlDataCount: () => {
         return 0;
     },
     GetActiveLossOfControlData: (

--- a/index.ts
+++ b/index.ts
@@ -1258,9 +1258,9 @@ export const C_LossOfControl = {
     GetNumEvents: () => {
         return 0;
     },
-    GetActiveLossOfControlData(
+    GetActiveLossOfControlData: (
         eventIndex: number
-    ): LossOfControlData | undefined {
+    ) => LossOfControlData | undefined {
         return {
             locType: "SCHOOL_INTERRUPT",
             spellID: 19,

--- a/index.ts
+++ b/index.ts
@@ -1228,33 +1228,6 @@ export interface LossOfControlData {
 }
 
 export const C_LossOfControl = {
-    GetEventInfo: (
-        eventIndex: number
-    ): [
-        string,
-        number,
-        string,
-        string,
-        number,
-        number,
-        number,
-        number,
-        number,
-        number
-    ] => {
-        return [
-            "SCHOOL_INTERRUPT",
-            33786,
-            "Interrupted",
-            "texture",
-            0,
-            7,
-            8,
-            1,
-            0,
-            2,
-        ];
-    },
     GetNumEvents: () => {
         return 0;
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@wowts/wow-mock",
-    "version": "1.21.0",
+    "version": "1.21.1",
     "description": "",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
yarn prepare translates it to C_LossOfControl:GetActiveLossOfControlData(eventIndex) (which gives a LUA error in game) instead of C_LossOfControl.GetActiveLossOfControlData(eventIndex)