### PR TITLE
fix: move some global symbols back inside Enum table

### DIFF
--- a/src/api/Soulbinds.ts
+++ b/src/api/Soulbinds.ts
@@ -1,15 +1,10 @@
-import {
-    SoulbindConduitType,
-    SoulbindNodeState,
-    SoulbindConduitTransactionType,
-} from "../mixins";
 import { LuaArray } from "@wowts/lua";
 import { UIFrame } from "../ui";
 export interface ConduitCollectionData {
     conduitID: number;
     conduitRank: number;
     conduitItemLevel: number;
-    conduitType: SoulbindConduitType;
+    conduitType: number; // Enum.SoulbindConduitType
     conduitSpecSetID: number;
     conduitSpecIDs: LuaArray<number>;
     conduitSpecName: string | undefined;
@@ -46,8 +41,8 @@ export interface SoulbindNode {
     playerConditionReason: string | undefined;
     conduitID: number;
     conduitRank: number;
-    state: SoulbindNodeState;
-    conduitType: SoulbindConduitType | undefined;
+    state: number; // Enum.SoulbindNodeState
+    conduitType: number | undefined; // Enum.SoulbindConduitType | undefined
     parentNodeIDs: LuaArray<number>;
     failureRenownRequirement: number | undefined;
     socketEnhanced: boolean | undefined;
@@ -110,7 +105,7 @@ export const C_Soulbinds = {
         return 0;
     },
     GetConduitCollection: (
-        conduitType: SoulbindConduitType
+        conduitType: number // Enum.SoulbindConduitType
     ): LuaArray<ConduitCollectionData> => {
         return {} as any;
     },
@@ -255,7 +250,7 @@ export const C_Soulbinds = {
     ModifyNode: (
         nodeID: number,
         conduitID: number,
-        type: SoulbindConduitTransactionType
+        type: number // Enum.SoulbindConduitTransactionType
     ): void => {},
     SelectNode: (nodeID: number): void => {},
     UnmodifyNode: (nodeID: number): void => {},

--- a/src/api/WeeklyRewards.ts
+++ b/src/api/WeeklyRewards.ts
@@ -1,4 +1,3 @@
-import { WeeklyRewardChestThresholdType, CachedRewardType } from "../mixins";
 import { LuaArray } from "@wowts/lua";
 import { UIFrame } from "../ui";
 export const enum ConquestProgressBarDisplayType {
@@ -21,7 +20,7 @@ export interface WeeklyRewardActivityEncounterInfo {
     instanceID: number;
 }
 export interface WeeklyRewardActivityInfo {
-    type: WeeklyRewardChestThresholdType;
+    type: number; // Enum.WeeklyRewardChestThresholdType
     index: number;
     threshold: number;
     progress: number;
@@ -31,7 +30,7 @@ export interface WeeklyRewardActivityInfo {
     rewards: LuaArray<WeeklyRewardActivityRewardInfo>;
 }
 export interface WeeklyRewardActivityRewardInfo {
-    type: CachedRewardType;
+    type: number; // Enum.CachedRewardType
     id: number;
     quantity: number;
     itemDBID: string | undefined;
@@ -46,12 +45,12 @@ export const C_WeeklyRewards = {
     ClaimReward: (id: number): void => {},
     CloseInteraction: (): void => {},
     GetActivities: (
-        type: WeeklyRewardChestThresholdType | undefined
+        type: number | undefined // Enum.WeeklyRewardChestThresholdType | undefined
     ): LuaArray<WeeklyRewardActivityInfo> => {
         return {} as any;
     },
     GetActivityEncounterInfo: (
-        type: WeeklyRewardChestThresholdType,
+        type: number, // Enum.WeeklyRewardChestThresholdType
         index: number
     ): LuaArray<WeeklyRewardActivityEncounterInfo> => {
         return {} as any;

--- a/src/api/enum.ts
+++ b/src/api/enum.ts
@@ -2365,4 +2365,34 @@ export const Enum = {
         Mainhand: 11,
         Offhand: 12,
     },
+    SoulbindConduitTransactionType: {
+		Install: 0,
+		Uninstall: 1,
+	},
+    SoulbindConduitType: {
+		Finesse: 0,
+		Potency: 1,
+		Endurance: 2,
+		Flex: 3,
+	},
+	SoulbindNodeState: {
+		Unavailable: 0,
+		Unselected: 1,
+		Selectable: 2,
+		Selected: 3,
+	},
+	CachedRewardType: {
+		None: 0,
+		Item: 1,
+		Currency: 2,
+		Quest: 3,
+	},
+	WeeklyRewardChestThresholdType: {
+		None: 0,
+		MythicPlus: 1,
+		RankedPvP: 2,
+		Raid: 3,
+		AlsoReceive: 4,
+		Concession: 5,
+	},
 };

--- a/src/mixins.ts
+++ b/src/mixins.ts
@@ -1,29 +1,8 @@
 import { LuaArray } from "@wowts/lua";
 import { BarberShopRaceData } from "./api";
 
-export const enum WeeklyRewardChestThresholdType {
-    None = 0,
-    MythicPlus = 1,
-    RankedPvP = 2,
-    Raid = 3,
-    AlsoReceive = 4,
-    Concession = 5,
-}
-export interface CachedRewardType {}
 export interface AppearanceSourceInfo {}
 export interface TradeSkillRecipeInfo {}
-export const enum SoulbindConduitType {
-    Finesse = 0,
-    Potency = 1,
-    Endurance = 2,
-    Flex = 3,
-}
-export const enum SoulbindNodeState {
-    Unavailable = 0,
-    Unselected = 1,
-    Selectable = 2,
-    Selected = 3,
-}
 export interface SoulbindConduitTransactionType {}
 export interface GuildTabardInfo {}
 export interface QueueSpecificInfo {}


### PR DESCRIPTION
WoW does not have the following global symbols:

  SoulbindConduitTransactionType
  SoulbindConduitType
  SoulbindNodeState
  CachedRewardType
  WeeklyRewardChestThresholdType

Instead, they are all found under the global Enum table.